### PR TITLE
Update part-block-gmap.php

### DIFF
--- a/template-parts/part-block-gmap.php
+++ b/template-parts/part-block-gmap.php
@@ -22,4 +22,4 @@ if ($show) :
 		<iframe src="<?php echo $src; ?>" width="100%" height="450" frameborder="0" style="border:0" allowfullscreen></iframe>
 	</section>
 
-<? endif; ?>
+<?php endif; ?>


### PR DESCRIPTION
Causes error if server has PHP short_open_tags turned off. Replaced by <?php
